### PR TITLE
Don't report changes from None to 'none' (=> None)

### DIFF
--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -883,7 +883,10 @@ def prefs(vmname, *varargs, **kwargs):
 
         # Value matches; no need to update
         value_new = kwargs[key]
-        if value_current == value_new:
+        vals_are_none = value_new == 'none' and value_current is None
+        noneable_keys = ['netvm', 'dispvm_netvm', 'kernel', 'drive']
+        equiv_none = vals_are_none and key in noneable_keys
+        if value_current == value_new or equiv_none:
             message = fmt.format(dest, value_current)
             qvm.save_status(prefix='[SKIP] ', message=message)
             continue


### PR DESCRIPTION
Without this, you get:
```
----------
          ID: keys-fedora
    Function: qvm.vm
      Result: True
     Comment: ====== ['present'] ======
              [SKIP] A VM with the name 'keys-fedora' already exists.
              
              ====== ['prefs'] ======
              /usr/bin/qvm-prefs  --set keys-fedora netvm "none" 
              [SKIP] template           : f24m-split-gpg
     Started: 15:22:17.552207
    Duration: 779.523 ms
     Changes:   
              ----------
              qvm.prefs:
                  ----------
                  qvm.create:
                      ----------
                      netvm:
                          ----------
                          new:
                              none
                          old:
                              None
----------
```
each time you try to apply a state regardless of how many times you try.

Some qvm-prefs properties take 'none' and interpret it as None.
This state module compares the None to 'none' and (kinda rightly)
reports a difference. What it doesn't realize though is that
qvm-prefs turns 'none' into None for certain properties.

To be on the safe side, only do this for those specific properties
which already do 'none' => None, and require other (future) ones
to be added here too.

---

This PR is against release3.2 because I was unable to test it against master. When I try to apply states (from qubes-infrastructure) with this repo's master (and no additional changes) installed in dom0, I get:
```
[root@dom0 build-infra]# qubesctl --targets local state.highstate                                                                                            |            fedora-23-dvm |    |    Halted |       |       |              fedora-23 | *sys-firewall |   gray |                                               
[ERROR   ] State 'qvm.vm' was not found in SLS 'build-infra.dom0'                                                                                            |      [fedora-24-minimal] |    |    Halted |   Yes |   Tpl |                    n/a | *sys-firewall |  black |
Reason: Module 'qvm' is not available.                                                                                                                       |           [f24m-net-tpl] |    |    Halted |   Yes |   Tpl |                    n/a | *sys-firewall |  black |
                                                                                                                                                             |  [f24m-autobuilder-logs] |    |    Halted |   Yes |   Tpl |                    n/a | *sys-firewall |  black |                                               
[ERROR   ] State 'qvm.vm' was not found in SLS 'build-infra.dom0'                                                                                            |               build-logs |    |    Halted |       |       |  f24m-autobuilder-logs | *sys-firewall |  green |
Reason: Module 'qvm' is not available.                                                                                                                       |              [f24m-base] |    |    Halted |   Yes |   Tpl |                    n/a | *sys-firewall |  black |                                               
                                                                                                                                                             |             mail-testing |    |    Halted |       |       |              f24m-base | *sys-firewall | purple |
[ERROR   ] State 'qvm.vm' was not found in SLS 'build-infra.dom0'                                                                                            | [f24m-autobuilder-build] |    |    Halted |   Yes |   Tpl |                    n/a | *sys-firewall |  black |                                               
Reason: Module 'qvm' is not available.                                                                                                                       |             build-fedora |    |    Halted |       |       | f24m-autobuilder-build | *sys-firewall |  green |
                                                                                                                                                             |         [f24m-split-gpg] |    |    Halted |   Yes |   Tpl |                    n/a | *sys-firewall |  black |                                               
local:                                                                                                                                                       |              keys-fedora |    |    Halted |       |       |         f24m-split-gpg |             - |  black |
----------                                                                                                                                                   |
          ID: build-logs                                                                                                                                     |
    Function: qvm.vm                                                                                                                                         |
      Result: False                                                                                                                                          |
     Comment: State 'qvm.vm' was not found in SLS 'build-infra.dom0'                                                                                         |
              Reason: Module 'qvm' is not available.                                                                                                         |
     Started:                                                                                                                                                |
    Duration:                                                                                                                                                |
     Changes:                                                                                                                                                |
----------                                                                                                                                                   |
...
```

Perhaps I would have needed to build/install master of all mgmt-* repos? Or perhaps it's just currently broken? I am still new to salt and not yet familiar with our mgmt-* code.