### PR TITLE
qvm.start: drop 'no-guid' 'tray' and 'dvm' flags as it does not exist…

### DIFF
--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -1594,7 +1594,7 @@ def run(vmname, *varargs, **kwargs):
     if args.auto:
         start_status = qvm.save_status(
             start(
-                args.vmname, **{'flags': ['quiet', 'no-guid']}
+                args.vmname, **{'flags': ['quiet']}
             )
         )
         if start_status.failed():
@@ -1634,33 +1634,15 @@ def start(vmname, *varargs, **kwargs):
         # Optional Flags
         - flags:
           - quiet
-          - tray
-          - no-guid
-          - dvm
           - debug
           - install-windows-tools
     '''
     qvm = _QVMBase('qvm.start', **kwargs)
     qvm.parser.add_argument('--quiet', action='store_true', help='Quiet')
     qvm.parser.add_argument(
-        '--tray',
-        action='store_true',
-        help='Use tray notifications instead of stdout'
-    )
-    qvm.parser.add_argument(
-        '--no-guid',
-        action='store_true',
-        help='Do not start the GUId (ignored)'
-    )
-    qvm.parser.add_argument(
         '--install-windows-tools',
         action='store_true',
         help='Attach Windows tools CDROM to the VM'
-    )
-    qvm.parser.add_argument(
-        '--dvm',
-        action='store_true',
-        help='Do actions necessary when preparing DVM image'
     )
     qvm.parser.add_argument(
         '--debug',

--- a/_states/ext_state_qvm.py
+++ b/_states/ext_state_qvm.py
@@ -198,7 +198,7 @@ def start(name, *varargs, **kwargs):
     Start vmname (qvm-start).
     '''
     kwargs.setdefault('flags', [])
-    kwargs['flags'].extend(['quiet', 'no-guid'])
+    kwargs['flags'].extend(['quiet'])
     return _state_action('qvm.start', name, *varargs, **kwargs)
 
 

--- a/tests/init.sls
+++ b/tests/init.sls
@@ -232,9 +232,6 @@ qvm-start-id:
     # custom-config: <string>
     # flags:
       # quiet  # *** salt default ***
-      # no-guid  # *** salt default ***
-      # tray
-      # dvm
       # debug
       # install-windows-tools
 {% endif %}

--- a/tests/tests-salt-call
+++ b/tests/tests-salt-call
@@ -429,7 +429,6 @@ fi
 #      # custom-config: <string>
 #      # flags:
 #        # quiet  # *** salt default ***
-#        # no-guid  # *** salt default ***
 #        # tray
 #        # dvm
 #        # debug
@@ -607,9 +606,6 @@ fi
 #          # another_test5
 #      - start: []
 #        # flags:
-#          # tray
-#          # no-guid
-#          # dvm
 #          # debug
 #          # install-windows-tools
 #          # drive: DRIVE


### PR DESCRIPTION
… anymore in qvm-start