### PR TITLE
Fix qvm.prefs, qvm.remove

### DIFF
--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -807,13 +807,6 @@ def prefs(vmname, *varargs, **kwargs):
     properties.add_argument('--updateable', nargs=1, type=bool)
     properties.add_argument('--vcpus', nargs=1, type=int)
 
-    # The following args seem not to exist in the Qubes R3.0 DB
-    # properties.add_argument('--timezone', nargs='?')
-    # properties.add_argument('--drive', nargs='?')
-    # properties.add_argument('--qrexec-installed', nargs='?', type=bool)
-    # properties.add_argument('--guiagent-installed', nargs='?', type=bool)
-    # properties.add_argument('--seamless-gui-mode', nargs='?', type=bool)
-
     # Maps property keys to vm attributes
     property_map = {
         'last_backup': 'backup_timestamp',

--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -670,6 +670,9 @@ def prefs(vmname, *varargs, **kwargs):
         - qrexec-timeout:       <int> (60)
         - vcpus:                <int>
 
+        # Read-only attributes
+        - klass
+
     Example:
 
     .. code-block:: yaml
@@ -779,6 +782,7 @@ def prefs(vmname, *varargs, **kwargs):
         nargs=1,
         type=bool
     )
+    properties.add_argument('--klass')
     properties.add_argument('--ip', nargs=1)
     properties.add_argument('--kernel', nargs=1)
     properties.add_argument('--kernelopts', nargs=1)
@@ -830,6 +834,12 @@ def prefs(vmname, *varargs, **kwargs):
             args.action = 'set'
         else:
             selected_properties = all_properties
+
+    # klass is a read-only attribute
+    if args.action == 'set' and 'klass' in kwargs:
+        raise SaltInvocationError(
+            message="Can't set read-only attribute 'klass'!"
+        )
 
     if 'action' in kwargs and kwargs['action'] == 'get' and varargs:
         result = set(varargs).difference(set(selected_properties))

--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -513,7 +513,7 @@ def remove(vmname, *varargs, **kwargs):
             return qvm.status()
 
     # Execute command (will not execute in test mode)
-    cmd = '/usr/bin/qvm-remove {0}'.format(' '.join(args._argv))  # pylint: disable=W0212
+    cmd = '/usr/bin/qvm-remove --force {0}'.format(' '.join(args._argv))  # pylint: disable=W0212
     status = qvm.run(cmd)  # pylint: disable=W0612
 
     # Confirm VM has been removed (don't fail in test mode)

--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -653,7 +653,6 @@ def prefs(vmname, *varargs, **kwargs):
         - virt-mode:            (hvm|pv)
         - include-in-backups:   true|false
         - installed-by-rpm:     true|false
-        - internal:             true|(false)
         - ip:                   <string>
         - kernel:               <string>
         - kernelopts:           <string>
@@ -668,7 +667,6 @@ def prefs(vmname, *varargs, **kwargs):
         - pci-strictreset:      true|false
         - pcidevs:              [string,]
         - template:             <string>
-        - type:                 <string>
         - qrexec-timeout:       <int> (60)
         - vcpus:                <int>
 
@@ -781,7 +779,6 @@ def prefs(vmname, *varargs, **kwargs):
         nargs=1,
         type=bool
     )
-    properties.add_argument('--internal', nargs=1, type=bool, default=False)
     properties.add_argument('--ip', nargs=1)
     properties.add_argument('--kernel', nargs=1)
     properties.add_argument('--kernelopts', nargs=1)
@@ -800,7 +797,6 @@ def prefs(vmname, *varargs, **kwargs):
     properties.add_argument('--provides-network', nargs=1, type=bool,
             default=False)
     properties.add_argument('--template', nargs=1)
-    properties.add_argument('--type', nargs=1)
     properties.add_argument(
         '--qrexec-timeout',
         '--qrexec_timeout',


### PR DESCRIPTION
`qubesctl qvm.prefs VMNAME` currently fails due to two old arguments that do not exist anymore in the Qubes core stack (`internal` and `type`). So remove them. Also remove commented-out arguments that were already removed back in R3.0 while we are at it.