### PR TITLE
qvm.firewall: add interface for firewall rules

### DIFF
--- a/_states/ext_state_qvm.py
+++ b/_states/ext_state_qvm.py
@@ -41,7 +41,7 @@ States and functions to implement (qvm-commands):
 
 [X] qvm-create
 [ ] qvm-create-default-dvm
-[ ] qvm-firewall
+[X] qvm-firewall
 [ ] qvm-grow-private
 [ ] qvm-grow-root
 [ ] qvm-init-storage
@@ -50,7 +50,7 @@ States and functions to implement (qvm-commands):
 
 [X] qvm-create
 [ ] qvm-create-default-dvm
-[ ] qvm-firewall
+[X] qvm-firewall
 [ ] qvm-grow-private
 [ ] qvm-grow-root
 [ ] qvm-init-storage
@@ -328,6 +328,13 @@ def tags(name, *varargs, **kwargs):
     return _state_action('qvm.tags', name, *varargs, **kwargs)
 
 
+def firewall(name, *varargs, **kwargs):
+    '''
+    Manage vmname firewall (qvm-firewall).
+    '''
+    return _state_action('qvm.firewall', name, *varargs, **kwargs)
+
+
 # pylint: disable=W0613,C0103
 def vm(name, *varargs, **kwargs):
     '''
@@ -380,6 +387,7 @@ def vm(name, *varargs, **kwargs):
         'devices',
         'service',
         'features',
+        'firewall',
         'tags',
         'unpause',
         'pause',


### PR DESCRIPTION
This PR exposes `qubesadmin.firewall.rules` through SaltStack.

The interface deviate from the command-line interface for `qvm-firewall` in that the only actions are `list` and `set`.  I'm not sure how important it is that salt modules/states correspond to the Qubes CLI tools, but only having to care for the previous state in boolean terms (i.e. whether the old rules match the new rules) seems preferable as far as idempotency is concerned.

Another weird quirk is that SaltStack interprets `k=w` command-line args as dictionaries, which means that both the single and multi-rule `set` action requires a `=` before the rules.  I'm not sure if there's a better way to force Salt to interpret arguments as strings.