### PR TITLE
qvm.prefs: add support for management-dispvm

### DIFF
--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -661,6 +661,7 @@ def prefs(vmname, *varargs, **kwargs):
         - debug:                true|(false)
         - default-user:         <string>
         - default-dispvm:       <string>
+        - management-dispvm:    <string>
         - guivm:                <string>
         - audiovm:              <string>
         - template-for-dispvms: true|false
@@ -766,6 +767,7 @@ def prefs(vmname, *varargs, **kwargs):
     properties.add_argument('--debug', nargs=1, type=bool, default=False)
     properties.add_argument('--default-user', '--default_user', nargs=1)
     properties.add_argument('--default-dispvm', '--default_dispvm', nargs=1)
+    properties.add_argument('--management-dispvm', '--management_dispvm', nargs=1)
     properties.add_argument('--guivm', nargs=1)
     properties.add_argument('--audiovm', nargs=1)
     properties.add_argument(


### PR DESCRIPTION
Previously, setting management-dispvm on a per-vm basis with qvm.prefs
had no effect because the argparser for prefs() didn't support this
option.

This commit adds management-dispvm as an argument for qvm.prefs.