### PR TITLE
Add arbitrary key/value example for qvm.features

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -341,6 +341,9 @@ Manage vmname features.
             - default:
                 - another_test5
                 - does_not_exist
+            - set:
+                - example.key: key value
+                - example.test: test value
             # list: []
             # list: [string,]
 


### PR DESCRIPTION
Features can have values, `qvm.features` supports setting them too but there is no example indicating this in the readme so far.