### PR TITLE
Add qvm.prefs pci_strictreset to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -248,6 +248,7 @@ default value.
             - include-in-backups: True
             - netvm:              sys-firewall
             - pcidevs:            ['04:00.0']
+            - pci-strictreset:    false
             - kernel:             default
             - vcpus:              2
             - kernelopts:         nopat iommu=soft swiotlb=8192


### PR DESCRIPTION
I ended up learning how to use `pci_strictreset` by reading the implementation, although I suppose I could have found the doc comment on `prefs` (was misled by the one on `devices`) or checked existing `.sls` files.

Used `kebab-case` to match current README style, though `.sls` files seem to generally use `snake_case`.