### PR TITLE
Adjust qvm.template_installed to use qvm-check

### DIFF
--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -208,12 +208,14 @@ def check(vmname, *varargs, **kwargs):
         # Optional Flags
         - flags:
           - quiet
+          - template
     """
     # Hide 'check' flag from argv as its not a valid qvm.check option
     qvm = _QVMBase('qvm.check', **kwargs)
     qvm.argparser.options['hide'] = ['check']
 
     qvm.parser.add_argument('--quiet', action='store_true', help='Quiet')
+    qvm.parser.add_argument('--template', action='store_true', help='Check if it is template')
     qvm.parser.add_argument(
         'vmname',
         action=_VMAction,

--- a/_states/ext_state_qvm.py
+++ b/_states/ext_state_qvm.py
@@ -472,11 +472,10 @@ def template_installed(name, fromrepo=None, pool=None, **kwargs):
         Install into given storage pool. Will not move already installed template.
     """
     ret = {'name': name, 'result': False, 'changes': {}, 'comment': ''}
-    info = __salt__['qvm.template_info'](name)
-    if info:
+    status = __salt__['qvm.check'](name, flags=['template'])
+    if status.passed():
         ret['result'] = True
-        ret['comment'] = 'Template {} version {} already installed'.format(
-                info['name'], info['version'])
+        ret['comment'] = 'Template {} already installed'.format(name)
         return ret
     if __opts__['test']:
         ret['result'] = None


### PR DESCRIPTION
Use qvm-check --template to check if the template exists. This covers the
case of in-place upgraded templates, in addition to those installed with
qvm-template directly.

Fixes QubesOS/qubes-issues#9818