### PR TITLE
Fix handling of already assigned PCI devices

### DIFF
--- a/_modules/ext_module_qvm.py
+++ b/_modules/ext_module_qvm.py
@@ -872,7 +872,7 @@ def prefs(vmname, *varargs, **kwargs):
         dest = property_map.get(dest, dest)
 
         if dest == 'pcidevs':
-            value_current = [str(dev.port_id).replace('_', ':') for dev
+            value_current = [str(dev.port_id) for dev
                              in args.vm.devices['pci'].get_assigned_devices(required_only=True)]
         elif dest == 'pci_strictreset':
             value_current = all(not assignment.options.get('no-strict-reset', False)


### PR DESCRIPTION
assign() raises DeviceAlreadyAssigned exception, not
DeviceAlreadyAttached. While at it, fix reporting changed devices
(report no change if nothing was changed), and also skip re-assigning if
options didn't change.