### PR TITLE
Fix odict deprecation warnings

### DIFF
--- a/_states/ext_state_qvm.py
+++ b/_states/ext_state_qvm.py
@@ -75,7 +75,7 @@ import logging
 # Import salt libs
 from salt.exceptions import (CommandExecutionError, SaltInvocationError)
 from salt.output import nested
-from salt.utils.odict import OrderedDict as _OrderedDict
+from salt.utils.datastructures import OrderedDict as _OrderedDict
 
 # Import custom libs
 import qubes_utils  # pylint: disable=F0401


### PR DESCRIPTION
### Description

Replace deprecated `salt.utils.odict.OrderedDict` with
`salt.utils.datastructures.OrderedDict`.

This removes the DeprecationWarning spam seen during `qubesctl` runs.

Note: This is part 2 of a two-part fix. The first part is in
`qubes-mgmt-salt-base-topd`.

Fixes QubesOS/qubes-issues#10742