### PR TITLE
qvm: propagate execution failures to state result (fixes #10752)

### DIFF
--- a/_states/ext_state_qvm.py
+++ b/_states/ext_state_qvm.py
@@ -137,7 +137,10 @@ def _state_action(_action, *varargs, **kwargs):
         status = __salt__[_action](*varargs, **kwargs)
     except (SaltInvocationError, CommandExecutionError) as err:
         status = Status(retcode=1, result=False, stderr=err.message + '\n')
-    return vars(status)
+    ret = vars(status)
+    if ret.get('retcode', 0) != 0:
+        ret['result'] = False
+    return ret
 
 
 def exists(name, *varargs, **kwargs):


### PR DESCRIPTION
### Description
Fix- Previously, a failed command could still return `result=True`
because the `Status` object was returned directly.

This patch ensures any non-zero retcode forces `result=False`.

Fixes QubesOS/qubes-issues#10752